### PR TITLE
Add MinSizeRel presets and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 build
 resources
 todo
+out
 
 #other
 reminder.txt

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,10 +24,29 @@
       }
     },
     {
+      "name": "linux-minsizerel",
+      "inherits": "base",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/linux-minsizerel",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel"
+      }
+    },
+    {
       "name": "windows-msvc-release",
       "inherits": "base",
       "generator": "Visual Studio 17 2022",
       "binaryDir": "${sourceDir}/out/build/windows-msvc-release",
+      "architecture": {
+        "strategy": "set",
+        "value": "x64"
+      }
+    },
+    {
+      "name": "windows-msvc-minsizerel",
+      "inherits": "base",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/out/build/windows-msvc-minsizerel",
       "architecture": {
         "strategy": "set",
         "value": "x64"
@@ -40,6 +59,15 @@
       "binaryDir": "${sourceDir}/out/build/windows-mingw-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "windows-mingw-minsizerel",
+      "inherits": "base",
+      "generator": "MinGW Makefiles",
+      "binaryDir": "${sourceDir}/out/build/windows-mingw-minsizerel",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel"
       }
     },
     {
@@ -59,13 +87,26 @@
       "configurePreset": "linux-release"
     },
     {
+      "name": "linux-minsizerel",
+      "configurePreset": "linux-minsizerel"
+    },
+    {
       "name": "windows-msvc-release",
       "configurePreset": "windows-msvc-release",
       "configuration": "Release"
     },
     {
+      "name": "windows-msvc-minsizerel",
+      "configurePreset": "windows-msvc-minsizerel",
+      "configuration": "MinSizeRel"
+    },
+    {
       "name": "windows-mingw-release",
       "configurePreset": "windows-mingw-release"
+    },
+    {
+      "name": "windows-mingw-minsizerel",
+      "configurePreset": "windows-mingw-minsizerel"
     },
     {
       "name": "ci-linux",

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ int main()
 Majimix now defaults to a bundled build: CMake downloads and builds libkss,
 libogg, libvorbis and PortAudio automatically.
 
+Bundled dependencies follow the selected build configuration. The Release and
+MinSizeRel presets therefore build both Majimix and the bundled dependencies in
+the same configuration.
+
 ### General prerequisites
 
 - CMake 3.21 or newer
@@ -142,6 +146,13 @@ Install into the default system prefix:
 sudo cmake --install out/build/linux-release
 ```
 
+Size-optimized MinSizeRel build:
+```sh
+cmake --preset linux-minsizerel
+cmake --build --preset linux-minsizerel
+cmake --install out/build/linux-minsizerel --prefix out/install/linux-minsizerel
+```
+
 ### Windows bundled build with MSVC
 
 Configure:
@@ -159,6 +170,13 @@ Install into a local test prefix:
 cmake --install out/build/windows-msvc-release --config Release --prefix out/install/windows-msvc-release
 ```
 
+Size-optimized MinSizeRel build:
+```powershell
+cmake --preset windows-msvc-minsizerel
+cmake --build --preset windows-msvc-minsizerel
+cmake --install out/build/windows-msvc-minsizerel --config MinSizeRel --prefix out/install/windows-msvc-minsizerel
+```
+
 ### Windows bundled build with MinGW
 
 Configure:
@@ -174,6 +192,13 @@ cmake --build --preset windows-mingw-release
 Install into a local test prefix:
 ```powershell
 cmake --install out/build/windows-mingw-release --prefix out/install/windows-mingw-release
+```
+
+Size-optimized MinSizeRel build:
+```powershell
+cmake --preset windows-mingw-minsizerel
+cmake --build --preset windows-mingw-minsizerel
+cmake --install out/build/windows-mingw-minsizerel --prefix out/install/windows-mingw-minsizerel
 ```
 
 ### Optional system dependencies mode


### PR DESCRIPTION
## Summary

- add MinSizeRel presets for Linux, Windows MSVC, and Windows MinGW
- document the new size-optimized build flows in the README
- ignore the `out/` build tree in Git

## Details

This change adds dedicated MinSizeRel presets so size-optimized builds can be used consistently across the supported generators:

- `linux-minsizerel`
- `windows-msvc-minsizerel`
- `windows-mingw-minsizerel`

The README is updated accordingly with configure, build, and install examples for these presets.

Because bundled dependencies are built through the same CMake configuration flow, the selected MinSizeRel configuration also applies to the bundled dependency builds.

## Validation

- `cmake --preset linux-minsizerel`
- `cmake --build --preset linux-minsizerel`

## Notes

- Linux MinSizeRel was validated locally
- the new Windows MinSizeRel presets were added for consistency with the existing cross-platform preset structure