### PR TITLE
Fix Windows linkage for Majimix wrappers

### DIFF
--- a/majimix.hpp.in
+++ b/majimix.hpp.in
@@ -225,8 +225,8 @@ public:
 	 * @return false A problem occurred and the operation could not be completed.
 	 */
 	virtual bool start_stop_mixer(bool start) = 0;
-	bool start_mixer();
-	bool stop_mixer();
+	bool start_mixer() { return start_stop_mixer(true); }
+	bool stop_mixer() { return start_stop_mixer(false); }
 	
 
 	/**
@@ -237,8 +237,8 @@ public:
 	 * @return false 
 	 */
 	virtual bool pause_resume_mixer(bool pause) = 0;
-	bool pause_mixer();
-	bool resume_mixer();
+	bool pause_mixer() { return pause_resume_mixer(true); }
+	bool resume_mixer() { return pause_resume_mixer(false); }
 
 	/**
 	 * @brief Get the mixer status
@@ -364,8 +364,8 @@ public:
 	 * @param pause 
 	 */
 	virtual void pause_resume_playback(int play_handle, bool pause) = 0;
-	void pause_playback(int play_handle);
-	void resume_playback(int play_handle);
+	void pause_playback(int play_handle) { pause_resume_playback(play_handle, true); }
+	void resume_playback(int play_handle) { pause_resume_playback(play_handle, false); }
 
 
 	/**

--- a/src/majimix.cpp
+++ b/src/majimix.cpp
@@ -70,41 +70,6 @@ static int get_handle(int source_id, int channel_id) { return ((channel_id & 0xF
 static int get_kss_source_id(int source_id) { return (source_id | 0x1000) & 0xFFFF; }
 static int get_source_type(int handle_or_source_id) { return (handle_or_source_id >> 12) & 0xF; }
 
-
-
-
-
-
-bool Majimix::start_mixer() 
-{
-	return start_stop_mixer(true);
-}
-
-bool Majimix::stop_mixer() 
-{
-	return start_stop_mixer(false);
-}
-
-bool Majimix::pause_mixer() 
-{
-	return pause_resume_mixer(true);
-}
-
-bool Majimix::resume_mixer() 
-{
-	return pause_resume_mixer(false);
-}
-
-void Majimix::pause_playback(int play_handle)
-{
-	pause_resume_playback(play_handle, true);
-}
-
-void Majimix::resume_playback(int play_handle)
-{
-	pause_resume_playback(play_handle, false);
-}
-
 /**
  * @class MixerChannel
  * @brief

--- a/src/majimix.hpp
+++ b/src/majimix.hpp
@@ -225,8 +225,8 @@ public:
 	 * @return false A problem occurred and the operation could not be completed.
 	 */
 	virtual bool start_stop_mixer(bool start) = 0;
-	bool start_mixer();
-	bool stop_mixer();
+	bool start_mixer() { return start_stop_mixer(true); }
+	bool stop_mixer() { return start_stop_mixer(false); }
 	
 
 	/**
@@ -237,8 +237,8 @@ public:
 	 * @return false 
 	 */
 	virtual bool pause_resume_mixer(bool pause) = 0;
-	bool pause_mixer();
-	bool resume_mixer();
+	bool pause_mixer() { return pause_resume_mixer(true); }
+	bool resume_mixer() { return pause_resume_mixer(false); }
 
 	/**
 	 * @brief Get the mixer status
@@ -364,8 +364,8 @@ public:
 	 * @param pause 
 	 */
 	virtual void pause_resume_playback(int play_handle, bool pause) = 0;
-	void pause_playback(int play_handle);
-	void resume_playback(int play_handle);
+	void pause_playback(int play_handle) { pause_resume_playback(play_handle, true); }
+	void resume_playback(int play_handle) { pause_resume_playback(play_handle, false); }
 
 
 	/**


### PR DESCRIPTION
**Description**

**_Summary_**

This change fixes Windows DLL consumption for the Majimix convenience wrapper methods.

Instead of making these wrapper methods virtual, they are now defined inline in the public header:

- start_mixer
- stop_mixer
- pause_mixer
- resume_mixer
- pause_playback
- resume_playback

Their out-of-line definitions were removed from the implementation file.

**_Why_**

These methods are only thin wrappers around the real virtual API:

- start_stop_mixer
- pause_resume_mixer
- pause_resume_playback

Keeping them as inline header wrappers avoids requiring dedicated exported wrapper symbols from the DLL on Windows, while also avoiding unnecessary virtual entries in the class interface.

This is a cleaner fix than making the wrappers virtual.

**_Validation_**

- Linux build still succeeds
- Linux to Windows cross-build of the DLL succeeds
- A small Windows test executable linking against the generated import library succeeds when calling the wrapper methods

**_Note for consumers_**

Projects that were previously built against the old header may need a clean rebuild, because stale object files can still reference the old out-of-line symbols