### PR TITLE
Add audio effects pipeline and built-in DSP effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,14 @@ project(majimix VERSION 0.5 DESCRIPTION "Simple audio mixer" LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(CTest)
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 option(MAJIMIX_USE_BUNDLED_DEPS "Download and build codec and audio dependencies automatically" ON)
 option(MAJIMIX_INSTALL_PKG_CONFIG "Install the pkg-config metadata on Unix platforms" ${UNIX})
 option(MAJIMIX_ENABLE_WARNINGS "Enable compiler warnings for Majimix sources" ON)
+option(MAJIMIX_BUILD_EXAMPLES "Build Majimix example programs" ${PROJECT_IS_TOP_LEVEL})
 
 set(default_build_type "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -72,6 +74,7 @@ endif()
 target_include_directories(${MAJIMIX_LIB_NAME}
     PUBLIC
         $<BUILD_INTERFACE:${MAJIMIX_GENERATED_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src"
@@ -110,6 +113,56 @@ install(TARGETS ${MAJIMIX_LIB_NAME}
 install(FILES "${MAJIMIX_CONFIGURED_HEADER}"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/majimix"
 )
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+if(MAJIMIX_BUILD_EXAMPLES)
+    add_executable(majimix_fade_playback_example
+        examples/fade_playback.cpp
+    )
+
+    add_executable(majimix_reverb_playback_example
+        examples/reverb_playback.cpp
+    )
+
+    add_executable(majimix_flanger_playback_example
+        examples/flanger_playback.cpp
+    )
+
+    add_executable(majimix_vibrato_playback_example
+        examples/vibrato_playback.cpp
+    )
+
+    add_executable(majimix_chorus_playback_example
+        examples/chorus_playback.cpp
+    )
+
+    target_compile_features(majimix_fade_playback_example PRIVATE cxx_std_17)
+    target_compile_features(majimix_reverb_playback_example PRIVATE cxx_std_17)
+    target_compile_features(majimix_flanger_playback_example PRIVATE cxx_std_17)
+    target_compile_features(majimix_vibrato_playback_example PRIVATE cxx_std_17)
+    target_compile_features(majimix_chorus_playback_example PRIVATE cxx_std_17)
+    target_link_libraries(majimix_fade_playback_example PRIVATE Majimix::pa)
+    target_link_libraries(majimix_reverb_playback_example PRIVATE Majimix::pa)
+    target_link_libraries(majimix_flanger_playback_example PRIVATE Majimix::pa)
+    target_link_libraries(majimix_vibrato_playback_example PRIVATE Majimix::pa)
+    target_link_libraries(majimix_chorus_playback_example PRIVATE Majimix::pa)
+endif()
+
+if(BUILD_TESTING AND PROJECT_IS_TOP_LEVEL)
+    add_executable(majimix_effects_smoke
+        tests/effects_smoke.cpp
+    )
+
+    target_compile_features(majimix_effects_smoke PRIVATE cxx_std_17)
+    target_include_directories(majimix_effects_smoke PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    )
+
+    add_test(NAME majimix_effects_smoke COMMAND majimix_effects_smoke)
+endif()
 
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/MajimixConfig.cmake.in"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,74 @@ int main()
 
 The playback event callback is optional. When registered, it should remain lightweight and non-blocking because loop notifications and natural stop notifications are emitted from the mixing thread.
 
+## Effects example
+
+```cpp
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <majimix/majimix.hpp>
+#include <majimix/effects.hpp>
+
+int main()
+{
+    majimix::pa::initialize();
+
+    auto majimix_ptr = majimix::pa::create_instance();
+    if (majimix_ptr->set_format(44100, true, 16, 10))
+    {
+        int source_handle = majimix_ptr->add_source("bgm.ogg");
+        if (source_handle && majimix_ptr->start_mixer())
+        {
+            auto master_gain = std::make_shared<majimix::GainEffect>(0.8f);
+            auto fade = std::make_shared<majimix::FadeEffect>(0.0f);
+
+            majimix_ptr->add_master_effect(master_gain);
+
+            int play_handle = majimix_ptr->play_source(source_handle, false, true);
+            majimix_ptr->add_playback_effect(play_handle, fade);
+
+            // Start silently, then fade in once the playback is resumed.
+            fade->fade_in(800);
+            majimix_ptr->resume_playback(play_handle);
+
+            std::this_thread::sleep_for(std::chrono::seconds(4));
+
+            master_gain->set_gain(0.6f);
+
+            // Fade out before stopping the playback.
+            fade->fade_out(1500);
+            std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+            majimix_ptr->stop_playback(play_handle);
+
+            // ... your application loop ...
+
+            majimix_ptr->stop_mixer();
+        }
+    }
+
+    majimix::pa::terminate();
+    return 0;
+}
+```
+
+Effects are processed in insertion order.
+
+- Master effects are applied to the full mixed signal.
+- Playback effects are applied to a single regular playback handle returned by play_source.
+- AudioEffect and built-in effects are declared in <majimix/effects.hpp>.
+- GainEffect applies a constant gain multiplier.
+- FadeEffect performs a linear fade toward a target gain over a duration expressed in milliseconds.
+- FadeEffect also provides the convenience helpers fade_in and fade_out.
+- ReverbEffect adds a simple room reverb controlled by room_size, damping, wet, dry and width.
+- VibratoEffect adds a pure modulated delay controlled by delay_ms, depth_ms, rate_hz and stereo_phase_deg.
+- ChorusEffect adds a modulated short delay with delay_ms, depth_ms, rate_hz, mix, stereo_phase_deg and optional feedback.
+- FlangerEffect adds a shorter modulated delay with dry/wet mix and a stronger signed feedback range than ChorusEffect.
+- Example programs are available in examples/fade_playback.cpp, examples/reverb_playback.cpp, examples/flanger_playback.cpp, examples/vibrato_playback.cpp and examples/chorus_playback.cpp.
+- The example executables expect the audio file path as their first command-line argument.
+- You can implement custom effects by deriving from AudioEffect and overriding process.
+- The same effect instance should not be attached to multiple chains at the same time.
+
  ## Dependencies
 
  Majimix uses the following libraries:<br>

--- a/examples/chorus_playback.cpp
+++ b/examples/chorus_playback.cpp
@@ -1,0 +1,85 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include <majimix/majimix.hpp>
+#include <majimix/effects.hpp>
+
+int main(int argc, char **argv)
+{
+	if(argc < 2)
+	{
+		std::cerr << "usage: " << argv[0] << " <audio-file>\n";
+		return 1;
+	}
+
+	const char *source_path = argv[1];
+
+	majimix::pa::initialize();
+
+	auto majimix_ptr = majimix::pa::create_instance();
+	if(!majimix_ptr || !majimix_ptr->set_format(44100, true, 16, 8))
+	{
+		std::cerr << "unable to initialize the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	const int source_handle = majimix_ptr->add_source(source_path);
+
+	if(!source_handle)
+	{
+		std::cerr << "unable to load " << source_path << "\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	if(!majimix_ptr->start_mixer())
+	{
+		std::cerr << "unable to start the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	auto chorus = std::make_shared<majimix::ChorusEffect>(18.0f, 3.5f, 0.28f, 0.4f, 0.12f, 120.0f);
+	const int play_handle = majimix_ptr->play_source(source_handle, true, false);
+	if(!play_handle)
+	{
+		std::cerr << "unable to start playback\n";
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "playback dry for 4 seconds...\n";
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	if(majimix_ptr->add_playback_effect(play_handle, chorus) == majimix::InvalidEffectHandle)
+	{
+		std::cerr << "unable to attach chorus effect\n";
+		majimix_ptr->stop_playback(play_handle);
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "chorus running...\n";
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "wider stereo modulation...\n";
+	chorus->set_stereo_phase_deg(180.0f);
+	chorus->set_depth_ms(4.5f);
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "slightly more feedback and mix...\n";
+	chorus->set_feedback(0.18f);
+	chorus->set_mix(0.5f);
+	chorus->set_rate_hz(0.35f);
+	std::this_thread::sleep_for(std::chrono::seconds(6));
+
+	majimix_ptr->stop_playback(play_handle);
+	majimix_ptr->stop_mixer();
+	majimix::pa::terminate();
+	return 0;
+}

--- a/examples/fade_playback.cpp
+++ b/examples/fade_playback.cpp
@@ -1,0 +1,80 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include <majimix/majimix.hpp>
+#include <majimix/effects.hpp>
+
+int main(int argc, char **argv)
+{
+	if(argc < 2)
+	{
+		std::cerr << "usage: " << argv[0] << " <audio-file>\n";
+		return 1;
+	}
+
+	const char *source_path = argv[1];
+
+	majimix::pa::initialize();
+
+	auto majimix_ptr = majimix::pa::create_instance();
+	if(!majimix_ptr || !majimix_ptr->set_format(44100, true, 16, 8))
+	{
+		std::cerr << "unable to initialize the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	const int source_handle = majimix_ptr->add_source(source_path);
+	if(!source_handle)
+	{
+		std::cerr << "unable to load " << source_path << "\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	if(!majimix_ptr->start_mixer())
+	{
+		std::cerr << "unable to start the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	auto master_gain = std::make_shared<majimix::GainEffect>(0.85f);
+	auto fade = std::make_shared<majimix::FadeEffect>(0.0f);
+
+	majimix_ptr->add_master_effect(master_gain);
+
+	const int play_handle = majimix_ptr->play_source(source_handle, false, true);
+	if(!play_handle)
+	{
+		std::cerr << "unable to start playback\n";
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	if(majimix_ptr->add_playback_effect(play_handle, fade) == majimix::InvalidEffectHandle)
+	{
+		std::cerr << "unable to attach fade effect\n";
+		majimix_ptr->stop_playback(play_handle);
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "fade in...\n";
+	fade->fade_in(800);
+	majimix_ptr->resume_playback(play_handle);
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "fade out...\n";
+	fade->fade_out(1200);
+	std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+	majimix_ptr->stop_playback(play_handle);
+	majimix_ptr->stop_mixer();
+	majimix::pa::terminate();
+	return 0;
+}

--- a/examples/flanger_playback.cpp
+++ b/examples/flanger_playback.cpp
@@ -1,0 +1,85 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include <majimix/effects.hpp>
+#include <majimix/majimix.hpp>
+
+int main(int argc, char **argv)
+{
+	if(argc < 2)
+	{
+		std::cerr << "usage: " << argv[0] << " <audio-file>\n";
+		return 1;
+	}
+
+	const char *source_path = argv[1];
+
+	majimix::pa::initialize();
+
+	auto majimix_ptr = majimix::pa::create_instance();
+	if(!majimix_ptr || !majimix_ptr->set_format(44100, true, 16, 8))
+	{
+		std::cerr << "unable to initialize the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	const int source_handle = majimix_ptr->add_source(source_path);
+	if(!source_handle)
+	{
+		std::cerr << "unable to load " << source_path << "\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	if(!majimix_ptr->start_mixer())
+	{
+		std::cerr << "unable to start the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	auto flanger = std::make_shared<majimix::FlangerEffect>(2.0f, 1.5f, 0.18f, 0.55f, 0.72f, 90.0f);
+	const int play_handle = majimix_ptr->play_source(source_handle, true, false);
+	if(!play_handle)
+	{
+		std::cerr << "unable to start playback\n";
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "playback dry for 3 seconds...\n";
+	std::this_thread::sleep_for(std::chrono::seconds(3));
+
+	if(majimix_ptr->add_playback_effect(play_handle, flanger) == majimix::InvalidEffectHandle)
+	{
+		std::cerr << "unable to attach flanger effect\n";
+		majimix_ptr->stop_playback(play_handle);
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "classic flanger running...\n";
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "stronger jet sweep...\n";
+	flanger->set_depth_ms(2.4f);
+	flanger->set_mix(0.7f);
+	flanger->set_feedback(0.82f);
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "negative feedback character...\n";
+	flanger->set_feedback(-0.78f);
+	flanger->set_rate_hz(0.3f);
+	flanger->set_stereo_phase_deg(180.0f);
+	std::this_thread::sleep_for(std::chrono::seconds(5));
+
+	majimix_ptr->stop_playback(play_handle);
+	majimix_ptr->stop_mixer();
+	majimix::pa::terminate();
+	return 0;
+}

--- a/examples/reverb_playback.cpp
+++ b/examples/reverb_playback.cpp
@@ -1,0 +1,87 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include <majimix/effects.hpp>
+#include <majimix/majimix.hpp>
+
+int main(int argc, char **argv)
+{
+	if(argc < 2)
+	{
+		std::cerr << "usage: " << argv[0] << " <audio-file>\n";
+		return 1;
+	}
+
+	const char *source_path = argv[1];
+
+	majimix::pa::initialize();
+
+	auto majimix_ptr = majimix::pa::create_instance();
+	if(!majimix_ptr || !majimix_ptr->set_format(44100, true, 16, 8))
+	{
+		std::cerr << "unable to initialize the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	const int source_handle = majimix_ptr->add_source(source_path);
+	if(!source_handle)
+	{
+		std::cerr << "unable to load " << source_path << "\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	if(!majimix_ptr->start_mixer())
+	{
+		std::cerr << "unable to start the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	auto reverb = std::make_shared<majimix::ReverbEffect>(0.55f, 0.2f, 0.0f, 1.0f, 1.0f);
+	if(majimix_ptr->add_master_effect(reverb) == majimix::InvalidEffectHandle)
+	{
+		std::cerr << "unable to attach reverb effect\n";
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	const int play_handle = majimix_ptr->play_source(source_handle, true, false);
+	if(!play_handle)
+	{
+		std::cerr << "unable to start playback\n";
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "playback dry for 3 seconds...\n";
+	std::this_thread::sleep_for(std::chrono::seconds(3));
+
+	std::cout << "small room reverb...\n";
+	reverb->set_wet(0.18f);
+	reverb->set_room_size(0.55f);
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "larger brighter room...\n";
+	reverb->set_room_size(0.78f); 
+	reverb->set_width(1.0f); 
+	reverb->set_wet(0.42f);
+	std::this_thread::sleep_for(std::chrono::seconds(5));
+
+	std::cout << "darker longer tail...\n";
+    reverb->set_room_size(1.f);
+	reverb->set_damping(0.45f);
+	reverb->set_wet(0.53f);
+	reverb->set_dry(0.95f);
+	std::this_thread::sleep_for(std::chrono::seconds(5));
+
+	majimix_ptr->stop_playback(play_handle);
+	majimix_ptr->stop_mixer();
+	majimix::pa::terminate();
+	return 0;
+}

--- a/examples/vibrato_playback.cpp
+++ b/examples/vibrato_playback.cpp
@@ -1,0 +1,83 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+#include <majimix/effects.hpp>
+#include <majimix/majimix.hpp>
+
+int main(int argc, char **argv)
+{
+	if(argc < 2)
+	{
+		std::cerr << "usage: " << argv[0] << " <audio-file>\n";
+		return 1;
+	}
+
+	const char *source_path = argv[1];
+
+	majimix::pa::initialize();
+
+	auto majimix_ptr = majimix::pa::create_instance();
+	if(!majimix_ptr || !majimix_ptr->set_format(44100, true, 16, 8))
+	{
+		std::cerr << "unable to initialize the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	const int source_handle = majimix_ptr->add_source(source_path);
+	if(!source_handle)
+	{
+		std::cerr << "unable to load " << source_path << "\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	if(!majimix_ptr->start_mixer())
+	{
+		std::cerr << "unable to start the mixer\n";
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	auto vibrato = std::make_shared<majimix::VibratoEffect>(2.0f, 1.f, 4.0f, 90.0f);
+	const int play_handle = majimix_ptr->play_source(source_handle, true, false);
+	if(!play_handle)
+	{
+		std::cerr << "unable to start playback\n";
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "playback dry for 3 seconds...\n";
+	std::this_thread::sleep_for(std::chrono::seconds(3));
+
+	if(majimix_ptr->add_playback_effect(play_handle, vibrato) == majimix::InvalidEffectHandle)
+	{
+		std::cerr << "unable to attach vibrato effect\n";
+		majimix_ptr->stop_playback(play_handle);
+		majimix_ptr->stop_mixer();
+		majimix::pa::terminate();
+		return 1;
+	}
+
+	std::cout << "subtle vibrato running...\n";
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "deeper stereo vibrato...\n";
+	vibrato->set_depth_ms(3.0f);
+	vibrato->set_stereo_phase_deg(180.0f);
+	std::this_thread::sleep_for(std::chrono::seconds(4));
+
+	std::cout << "faster vibrato...\n";
+	vibrato->set_rate_hz(6.0f);
+	vibrato->set_delay_ms(6.5f);
+	std::this_thread::sleep_for(std::chrono::seconds(5));
+
+	majimix_ptr->stop_playback(play_handle);
+	majimix_ptr->stop_mixer();
+	majimix::pa::terminate();
+	return 0;
+}

--- a/include/majimix/effects.hpp
+++ b/include/majimix/effects.hpp
@@ -1,0 +1,881 @@
+#ifndef MAJIMIX_EFFECTS_HPP_
+#define MAJIMIX_EFFECTS_HPP_
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <vector>
+
+namespace majimix {
+
+class AudioEffect {
+public:
+	virtual ~AudioEffect() = default;
+
+	/**
+	 * @brief Prepare the effect for a mixer format.
+	 *
+	 * Called with the current mixer output format before processing begins.
+	 * The effect processes interleaved floating-point samples.
+	 *
+	 * @param [in] sample_rate mixer sample rate
+	 * @param [in] channels mixer channel count
+	 */
+	virtual void prepare([[maybe_unused]] int sample_rate, [[maybe_unused]] int channels)
+	{
+	}
+
+	/**
+	 * @brief Reset the internal effect state.
+	 */
+	virtual void reset() {}
+
+	/**
+	 * @brief Process an interleaved floating-point audio buffer in place.
+	 *
+	 * The buffer contains frame_count * channels samples.
+	 *
+	 * @param [in,out] samples interleaved floating-point samples
+	 * @param [in] frame_count number of audio frames in the buffer
+	 */
+	virtual void process(float *samples, int frame_count) = 0;
+};
+
+class GainEffect final : public AudioEffect {
+public:
+	explicit GainEffect(float gain = 1.0f)
+		: gain_ {sanitize_gain(gain)}
+	{
+	}
+
+	void prepare([[maybe_unused]] int sample_rate, int channels) override
+	{
+		channel_count_.store(channels > 0 ? channels : 1, std::memory_order_relaxed);
+	}
+
+	void set_gain(float gain)
+	{
+		gain_.store(sanitize_gain(gain), std::memory_order_relaxed);
+	}
+
+	float get_gain() const
+	{
+		return gain_.load(std::memory_order_relaxed);
+	}
+
+	void process(float *samples, int frame_count) override
+	{
+		if(!samples || frame_count <= 0)
+			return;
+
+		const int sample_count = frame_count * channel_count_.load(std::memory_order_relaxed);
+		const float gain = gain_.load(std::memory_order_relaxed);
+		for(int i = 0; i < sample_count; ++i)
+			samples[i] *= gain;
+	}
+
+private:
+	static float sanitize_gain(float gain)
+	{
+		return gain < 0.0f ? 0.0f : gain;
+	}
+
+	std::atomic<float> gain_;
+	std::atomic<int> channel_count_ {1};
+};
+
+class FadeEffect final : public AudioEffect {
+public:
+	explicit FadeEffect(float initial_gain = 1.0f)
+		: reset_gain_ {sanitize_gain(initial_gain)},
+		  current_gain_value_ {sanitize_gain(initial_gain)},
+		  command_target_gain_ {sanitize_gain(initial_gain)},
+		  current_gain_ {sanitize_gain(initial_gain)},
+		  target_gain_ {sanitize_gain(initial_gain)}
+	{
+	}
+
+	void prepare(int sample_rate, int channels) override
+	{
+		sample_rate_.store(sample_rate > 0 ? sample_rate : 44100, std::memory_order_relaxed);
+		channel_count_.store(channels > 0 ? channels : 1, std::memory_order_relaxed);
+		reset();
+	}
+
+	void reset() override
+	{
+		const float gain = reset_gain_.load(std::memory_order_relaxed);
+		current_gain_ = gain;
+		target_gain_ = gain;
+		gain_step_ = 0.0f;
+		remaining_frames_ = 0;
+		current_gain_value_.store(gain, std::memory_order_relaxed);
+		applied_command_version_ = 0;
+	}
+
+	void set_gain(float gain)
+	{
+		const float sanitized_gain = sanitize_gain(gain);
+		reset_gain_.store(sanitized_gain, std::memory_order_relaxed);
+		publish_command(sanitized_gain, 0, true);
+	}
+
+	float get_current_gain() const
+	{
+		return current_gain_value_.load(std::memory_order_relaxed);
+	}
+
+	float get_target_gain() const
+	{
+		return command_target_gain_.load(std::memory_order_relaxed);
+	}
+
+	void fade_to(float target_gain, int duration_ms)
+	{
+		publish_command(sanitize_gain(target_gain), duration_ms < 0 ? 0 : duration_ms, false);
+	}
+
+	void fade_in(int duration_ms)
+	{
+		fade_to(1.0f, duration_ms);
+	}
+
+	void fade_out(int duration_ms)
+	{
+		fade_to(0.0f, duration_ms);
+	}
+
+	void process(float *samples, int frame_count) override
+	{
+		if(!samples || frame_count <= 0)
+			return;
+
+		apply_pending_command();
+
+		const int channel_count = channel_count_.load(std::memory_order_relaxed);
+		int sample_index = 0;
+		if(remaining_frames_ <= 0)
+		{
+			for(int frame = 0; frame < frame_count; ++frame)
+			{
+				const float gain = current_gain_;
+				for(int channel = 0; channel < channel_count; ++channel)
+					samples[sample_index++] *= gain;
+			}
+		}
+		else
+		{
+			for(int frame = 0; frame < frame_count; ++frame)
+			{
+				const float gain = current_gain_;
+				for(int channel = 0; channel < channel_count; ++channel)
+					samples[sample_index++] *= gain;
+
+				if(remaining_frames_ > 0)
+				{
+					current_gain_ += gain_step_;
+					--remaining_frames_;
+					if(remaining_frames_ == 0)
+					{
+						current_gain_ = target_gain_;
+						gain_step_ = 0.0f;
+					}
+				}
+			}
+		}
+
+		current_gain_value_.store(current_gain_, std::memory_order_relaxed);
+	}
+
+private:
+	static float sanitize_gain(float gain)
+	{
+		return gain < 0.0f ? 0.0f : gain;
+	}
+
+	void publish_command(float target_gain, int duration_ms, bool immediate)
+	{
+		command_version_.fetch_add(1, std::memory_order_acq_rel);
+		command_target_gain_.store(target_gain, std::memory_order_release);
+		command_duration_ms_.store(duration_ms, std::memory_order_release);
+		command_immediate_.store(immediate, std::memory_order_release);
+		command_version_.fetch_add(1, std::memory_order_acq_rel);
+	}
+
+	void read_pending_command(float &target_gain, int &duration_ms, bool &immediate, unsigned int &version) const
+	{
+		for(;;)
+		{
+			const unsigned int version_before = command_version_.load(std::memory_order_acquire);
+			if(version_before & 1U)
+				continue;
+
+			target_gain = command_target_gain_.load(std::memory_order_acquire);
+			duration_ms = command_duration_ms_.load(std::memory_order_acquire);
+			immediate = command_immediate_.load(std::memory_order_acquire);
+
+			const unsigned int version_after = command_version_.load(std::memory_order_acquire);
+			if(version_before == version_after)
+			{
+				version = version_after;
+				return;
+			}
+		}
+	}
+
+	void apply_pending_command()
+	{
+		float requested_target_gain = 0.0f;
+		int requested_duration_ms = 0;
+		bool immediate = true;
+		unsigned int version = 0;
+		read_pending_command(requested_target_gain, requested_duration_ms, immediate, version);
+		if(version == applied_command_version_)
+			return;
+
+		applied_command_version_ = version;
+		if(immediate || requested_duration_ms <= 0)
+		{
+			current_gain_ = requested_target_gain;
+			target_gain_ = requested_target_gain;
+			gain_step_ = 0.0f;
+			remaining_frames_ = 0;
+			current_gain_value_.store(current_gain_, std::memory_order_relaxed);
+			return;
+		}
+
+		const int sample_rate = sample_rate_.load(std::memory_order_relaxed);
+		remaining_frames_ = (sample_rate * requested_duration_ms) / 1000;
+		if(remaining_frames_ <= 0)
+			remaining_frames_ = 1;
+
+		target_gain_ = requested_target_gain;
+		gain_step_ = (target_gain_ - current_gain_) / static_cast<float>(remaining_frames_);
+	}
+
+	std::atomic<int> sample_rate_ {44100};
+	std::atomic<int> channel_count_ {1};
+	std::atomic<float> reset_gain_;
+	std::atomic<float> current_gain_value_;
+	std::atomic<unsigned int> command_version_ {0};
+	std::atomic<float> command_target_gain_;
+	std::atomic<int> command_duration_ms_ {0};
+	std::atomic<bool> command_immediate_ {true};
+
+	unsigned int applied_command_version_ {0};
+	float current_gain_ {1.0f};
+	float target_gain_ {1.0f};
+	float gain_step_ {0.0f};
+	int remaining_frames_ {0};
+};
+
+namespace detail {
+
+inline float sanitize_denormal_sample(float sample)
+{
+	return std::fabs(sample) < 1.0e-20f ? 0.0f : sample;
+}
+
+class ReverbCombFilter {
+public:
+	void prepare(int sample_count)
+	{
+		buffer_.assign(static_cast<size_t>(sample_count > 0 ? sample_count : 1), 0.0f);
+		reset();
+	}
+
+	void reset()
+	{
+		std::fill(buffer_.begin(), buffer_.end(), 0.0f);
+		index_ = 0;
+		filter_store_ = 0.0f;
+	}
+
+	float process(float input, float feedback, float damping)
+	{
+		if(buffer_.empty())
+			return input;
+
+		const float output = buffer_[static_cast<size_t>(index_)];
+		filter_store_ = sanitize_denormal_sample(output * (1.0f - damping) + filter_store_ * damping);
+		buffer_[static_cast<size_t>(index_)] = sanitize_denormal_sample(input + filter_store_ * feedback);
+		index_ = (index_ + 1) % static_cast<int>(buffer_.size());
+		return output;
+	}
+
+private:
+	std::vector<float> buffer_;
+	int index_ {0};
+	float filter_store_ {0.0f};
+};
+
+class ReverbAllPassFilter {
+public:
+	void prepare(int sample_count)
+	{
+		buffer_.assign(static_cast<size_t>(sample_count > 0 ? sample_count : 1), 0.0f);
+		reset();
+	}
+
+	void reset()
+	{
+		std::fill(buffer_.begin(), buffer_.end(), 0.0f);
+		index_ = 0;
+	}
+
+	float process(float input)
+	{
+		if(buffer_.empty())
+			return input;
+
+		const float buffered = buffer_[static_cast<size_t>(index_)];
+		const float output = sanitize_denormal_sample(buffered - input);
+		buffer_[static_cast<size_t>(index_)] = sanitize_denormal_sample(input + buffered * feedback());
+		index_ = (index_ + 1) % static_cast<int>(buffer_.size());
+		return output;
+	}
+
+private:
+	static constexpr float feedback() { return 0.5f; }
+
+	std::vector<float> buffer_;
+	int index_ {0};
+};
+
+class ModulatedDelayEffectBase : public AudioEffect {
+public:
+	ModulatedDelayEffectBase(float delay_ms, float depth_ms, float rate_hz, float stereo_phase_deg)
+		: delay_ms_ {sanitize_delay_ms(delay_ms)},
+		  depth_ms_ {sanitize_depth_ms(depth_ms)},
+		  rate_hz_ {sanitize_rate_hz(rate_hz)},
+		  stereo_phase_deg_ {sanitize_stereo_phase_deg(stereo_phase_deg)}
+	{
+	}
+
+	void prepare(int sample_rate, int channels) final
+	{
+		sample_rate_.store(sample_rate > 0 ? sample_rate : 44100, std::memory_order_relaxed);
+		channel_count_.store(channels > 0 ? channels : 1, std::memory_order_relaxed);
+
+		const int prepared_sample_rate = sample_rate_.load(std::memory_order_relaxed);
+		const int prepared_channels = channel_count_.load(std::memory_order_relaxed);
+		delay_buffer_frame_count_ = std::max(static_cast<int>(std::ceil(static_cast<float>(prepared_sample_rate) * max_supported_delay_ms() / 1000.0f)) + 2, 2);
+		delay_buffer_.assign(static_cast<size_t>(delay_buffer_frame_count_ * prepared_channels), 0.0f);
+		wet_frame_buffer_.assign(static_cast<size_t>(prepared_channels), 0.0f);
+		reset();
+	}
+
+	void reset() final
+	{
+		std::fill(delay_buffer_.begin(), delay_buffer_.end(), 0.0f);
+		std::fill(wet_frame_buffer_.begin(), wet_frame_buffer_.end(), 0.0f);
+		write_frame_index_ = 0;
+		lfo_phase_ = 0.0f;
+	}
+
+	void set_delay_ms(float delay_ms)
+	{
+		delay_ms_.store(sanitize_delay_ms(delay_ms), std::memory_order_relaxed);
+	}
+
+	float get_delay_ms() const
+	{
+		return delay_ms_.load(std::memory_order_relaxed);
+	}
+
+	void set_depth_ms(float depth_ms)
+	{
+		depth_ms_.store(sanitize_depth_ms(depth_ms), std::memory_order_relaxed);
+	}
+
+	float get_depth_ms() const
+	{
+		return depth_ms_.load(std::memory_order_relaxed);
+	}
+
+	void set_rate_hz(float rate_hz)
+	{
+		rate_hz_.store(sanitize_rate_hz(rate_hz), std::memory_order_relaxed);
+	}
+
+	float get_rate_hz() const
+	{
+		return rate_hz_.load(std::memory_order_relaxed);
+	}
+
+	void set_stereo_phase_deg(float stereo_phase_deg)
+	{
+		stereo_phase_deg_.store(sanitize_stereo_phase_deg(stereo_phase_deg), std::memory_order_relaxed);
+	}
+
+	float get_stereo_phase_deg() const
+	{
+		return stereo_phase_deg_.load(std::memory_order_relaxed);
+	}
+
+	void process(float *samples, int frame_count) final
+	{
+		if(!samples || frame_count <= 0 || delay_buffer_.empty())
+			return;
+
+		const int sample_rate = sample_rate_.load(std::memory_order_relaxed);
+		const int channel_count = channel_count_.load(std::memory_order_relaxed);
+		if(sample_rate <= 0 || channel_count <= 0)
+			return;
+
+		const float delay_ms = delay_ms_.load(std::memory_order_relaxed);
+		const float depth_ms = depth_ms_.load(std::memory_order_relaxed);
+		const float rate_hz = rate_hz_.load(std::memory_order_relaxed);
+		const float stereo_phase_rad = degrees_to_radians(stereo_phase_deg_.load(std::memory_order_relaxed));
+		const float phase_step = rate_hz > 0.0f ? rate_hz * two_pi() / static_cast<float>(sample_rate) : 0.0f;
+
+		for(int frame = 0; frame < frame_count; ++frame)
+		{
+			const int frame_offset = frame * channel_count;
+			const int write_frame_index = write_frame_index_;
+			const size_t write_offset = static_cast<size_t>(write_frame_index * channel_count);
+
+			for(int channel = 0; channel < channel_count; ++channel)
+				wet_frame_buffer_[static_cast<size_t>(channel)] = read_modulated_sample(samples[frame_offset + channel], channel,
+					write_frame_index, sample_rate, channel_count, delay_ms, depth_ms, stereo_phase_rad);
+
+			for(int channel = 0; channel < channel_count; ++channel)
+			{
+				const float dry = samples[frame_offset + channel];
+				const float wet = wet_frame_buffer_[static_cast<size_t>(channel)];
+				samples[frame_offset + channel] = output_sample(dry, wet);
+				delay_buffer_[write_offset + static_cast<size_t>(channel)] = delay_input_sample(dry, wet);
+			}
+
+			write_frame_index_ = (write_frame_index_ + 1) % delay_buffer_frame_count_;
+			lfo_phase_ = normalize_phase(lfo_phase_ + phase_step);
+		}
+	}
+
+	static constexpr float max_delay_ms_limit() { return 100.0f; }
+	static constexpr float max_depth_ms_limit() { return 20.0f; }
+	static constexpr float max_stereo_phase_deg_limit() { return 180.0f; }
+
+protected:
+	virtual float output_sample(float dry, float wet) const = 0;
+	virtual float delay_input_sample(float dry, float wet) const = 0;
+
+	static float sanitize_delay_ms(float delay_ms)
+	{
+		return std::clamp(delay_ms, 0.0f, max_delay_ms_limit());
+	}
+
+	static float sanitize_depth_ms(float depth_ms)
+	{
+		return std::clamp(depth_ms, 0.0f, max_depth_ms_limit());
+	}
+
+	static float sanitize_rate_hz(float rate_hz)
+	{
+		return rate_hz < 0.0f ? 0.0f : rate_hz;
+	}
+
+	static float sanitize_stereo_phase_deg(float stereo_phase_deg)
+	{
+		return std::clamp(stereo_phase_deg, 0.0f, max_stereo_phase_deg_limit());
+	}
+
+private:
+	static constexpr float max_supported_delay_ms() { return max_delay_ms_limit() + max_depth_ms_limit(); }
+	static constexpr float two_pi() { return 6.28318530717958647692f; }
+
+	static float degrees_to_radians(float degrees)
+	{
+		return degrees * (two_pi() / 360.0f);
+	}
+
+	static float normalize_phase(float phase)
+	{
+		while(phase >= two_pi())
+			phase -= two_pi();
+		while(phase < 0.0f)
+			phase += two_pi();
+		return phase;
+	}
+
+	float read_modulated_sample(float dry, int channel, int write_frame_index, int sample_rate, int channel_count,
+		float delay_ms, float depth_ms, float stereo_phase_rad) const
+	{
+		const float channel_phase = normalize_phase(lfo_phase_ + static_cast<float>(channel % 2) * stereo_phase_rad);
+		float modulated_delay_frames = (delay_ms + depth_ms * std::sin(channel_phase)) * static_cast<float>(sample_rate) / 1000.0f;
+		modulated_delay_frames = std::clamp(modulated_delay_frames, 0.0f, static_cast<float>(delay_buffer_frame_count_ - 1));
+		if(modulated_delay_frames <= 0.0f)
+			return dry;
+
+		float read_position = static_cast<float>(write_frame_index) - modulated_delay_frames;
+		while(read_position < 0.0f)
+			read_position += static_cast<float>(delay_buffer_frame_count_);
+
+		const int read_frame_index_0 = static_cast<int>(read_position);
+		const int read_frame_index_1 = (read_frame_index_0 + 1) % delay_buffer_frame_count_;
+		const float fraction = read_position - static_cast<float>(read_frame_index_0);
+		const size_t read_offset_0 = static_cast<size_t>(read_frame_index_0 * channel_count + channel);
+		const size_t read_offset_1 = static_cast<size_t>(read_frame_index_1 * channel_count + channel);
+
+		const float wet_0 = delay_buffer_[read_offset_0];
+		const float wet_1 = delay_buffer_[read_offset_1];
+		return wet_0 + (wet_1 - wet_0) * fraction;
+	}
+
+	std::atomic<float> delay_ms_;
+	std::atomic<float> depth_ms_;
+	std::atomic<float> rate_hz_;
+	std::atomic<float> stereo_phase_deg_;
+	std::atomic<int> sample_rate_ {44100};
+	std::atomic<int> channel_count_ {1};
+
+	int delay_buffer_frame_count_ {0};
+	int write_frame_index_ {0};
+	float lfo_phase_ {0.0f};
+	std::vector<float> delay_buffer_;
+	std::vector<float> wet_frame_buffer_;
+};
+
+class MixedFeedbackModulatedDelayEffectBase : public ModulatedDelayEffectBase {
+public:
+	MixedFeedbackModulatedDelayEffectBase(float delay_ms, float depth_ms, float rate_hz, float mix, float feedback,
+		float stereo_phase_deg, float min_feedback_limit, float max_feedback_limit)
+		: ModulatedDelayEffectBase(delay_ms, depth_ms, rate_hz, stereo_phase_deg),
+		  mix_ {sanitize_mix(mix)},
+		  feedback_ {sanitize_feedback(feedback, min_feedback_limit, max_feedback_limit)},
+		  min_feedback_limit_ {min_feedback_limit},
+		  max_feedback_limit_ {max_feedback_limit < 0.0f ? 0.0f : max_feedback_limit}
+	{
+	}
+
+	void set_mix(float mix)
+	{
+		mix_.store(sanitize_mix(mix), std::memory_order_relaxed);
+	}
+
+	float get_mix() const
+	{
+		return mix_.load(std::memory_order_relaxed);
+	}
+
+	void set_feedback(float feedback)
+	{
+		feedback_.store(sanitize_feedback(feedback, min_feedback_limit_, max_feedback_limit_), std::memory_order_relaxed);
+	}
+
+	float get_feedback() const
+	{
+		return feedback_.load(std::memory_order_relaxed);
+	}
+
+private:
+	static float sanitize_mix(float mix)
+	{
+		return std::clamp(mix, 0.0f, 1.0f);
+	}
+
+	static float sanitize_feedback(float feedback, float min_feedback_limit, float max_feedback_limit)
+	{
+		return std::clamp(feedback, min_feedback_limit, max_feedback_limit);
+	}
+
+	float output_sample(float dry, float wet) const final
+	{
+		const float mix = mix_.load(std::memory_order_relaxed);
+		return dry * (1.0f - mix) + wet * mix;
+	}
+
+	float delay_input_sample(float dry, float wet) const final
+	{
+		const float feedback = feedback_.load(std::memory_order_relaxed);
+		return dry + wet * feedback;
+	}
+
+	std::atomic<float> mix_;
+	std::atomic<float> feedback_;
+	const float min_feedback_limit_;
+	const float max_feedback_limit_;
+};
+
+} // namespace detail
+
+class ReverbEffect final : public AudioEffect {
+public:
+	ReverbEffect(float room_size = 0.65f, float damping = 0.25f, float wet = 0.18f, float dry = 1.0f, float width = 1.0f)
+		: room_size_ {sanitize_room_size(room_size)},
+		  damping_ {sanitize_damping(damping)},
+		  wet_ {sanitize_mix(wet)},
+		  dry_ {sanitize_mix(dry)},
+		  width_ {sanitize_width(width)}
+	{
+	}
+
+	void prepare(int sample_rate, int channels) override
+	{
+		sample_rate_.store(sample_rate > 0 ? sample_rate : 44100, std::memory_order_relaxed);
+		channel_count_.store(channels > 0 ? channels : 1, std::memory_order_relaxed);
+
+		const int prepared_sample_rate = sample_rate_.load(std::memory_order_relaxed);
+		const int prepared_channels = channel_count_.load(std::memory_order_relaxed);
+		comb_filters_.clear();
+		comb_filters_.resize(static_cast<size_t>(prepared_channels));
+		allpass_filters_.clear();
+		allpass_filters_.resize(static_cast<size_t>(prepared_channels));
+		wet_frame_buffer_.assign(static_cast<size_t>(prepared_channels), 0.0f);
+		dry_frame_buffer_.assign(static_cast<size_t>(prepared_channels), 0.0f);
+
+		for(int channel = 0; channel < prepared_channels; ++channel)
+		{
+			auto &comb_bank = comb_filters_[static_cast<size_t>(channel)];
+			for(size_t i = 0; i < comb_filter_count; ++i)
+				comb_bank[i].prepare(scale_delay_frames(comb_tunings()[i], prepared_sample_rate, channel));
+
+			auto &allpass_bank = allpass_filters_[static_cast<size_t>(channel)];
+			for(size_t i = 0; i < allpass_filter_count; ++i)
+				allpass_bank[i].prepare(scale_delay_frames(allpass_tunings()[i], prepared_sample_rate, channel));
+		}
+
+		reset();
+	}
+
+	void reset() override
+	{
+		for(auto &comb_bank : comb_filters_)
+			for(auto &comb : comb_bank)
+				comb.reset();
+
+		for(auto &allpass_bank : allpass_filters_)
+			for(auto &allpass : allpass_bank)
+				allpass.reset();
+
+		std::fill(wet_frame_buffer_.begin(), wet_frame_buffer_.end(), 0.0f);
+		std::fill(dry_frame_buffer_.begin(), dry_frame_buffer_.end(), 0.0f);
+	}
+
+	void set_room_size(float room_size)
+	{
+		room_size_.store(sanitize_room_size(room_size), std::memory_order_relaxed);
+	}
+
+	float get_room_size() const
+	{
+		return room_size_.load(std::memory_order_relaxed);
+	}
+
+	void set_damping(float damping)
+	{
+		damping_.store(sanitize_damping(damping), std::memory_order_relaxed);
+	}
+
+	float get_damping() const
+	{
+		return damping_.load(std::memory_order_relaxed);
+	}
+
+	void set_wet(float wet)
+	{
+		wet_.store(sanitize_mix(wet), std::memory_order_relaxed);
+	}
+
+	float get_wet() const
+	{
+		return wet_.load(std::memory_order_relaxed);
+	}
+
+	void set_dry(float dry)
+	{
+		dry_.store(sanitize_mix(dry), std::memory_order_relaxed);
+	}
+
+	float get_dry() const
+	{
+		return dry_.load(std::memory_order_relaxed);
+	}
+
+	void set_width(float width)
+	{
+		width_.store(sanitize_width(width), std::memory_order_relaxed);
+	}
+
+	float get_width() const
+	{
+		return width_.load(std::memory_order_relaxed);
+	}
+
+	void process(float *samples, int frame_count) override
+	{
+		if(!samples || frame_count <= 0 || comb_filters_.empty() || allpass_filters_.empty())
+			return;
+
+		const int channel_count = channel_count_.load(std::memory_order_relaxed);
+		if(channel_count <= 0)
+			return;
+
+		const float room_size = room_size_.load(std::memory_order_relaxed);
+		const float damping = damping_.load(std::memory_order_relaxed);
+		const float wet = wet_.load(std::memory_order_relaxed);
+		const float dry = dry_.load(std::memory_order_relaxed);
+		const float width = width_.load(std::memory_order_relaxed);
+		const float comb_feedback = room_size_to_comb_feedback(room_size);
+		const float comb_damping = damping_to_comb_damping(damping);
+		const float wet_1 = channel_count == 2 ? wet * (width * 0.5f + 0.5f) : wet;
+		const float wet_2 = channel_count == 2 ? wet * ((1.0f - width) * 0.5f) : 0.0f;
+
+		for(int frame = 0; frame < frame_count; ++frame)
+		{
+			const int frame_offset = frame * channel_count;
+
+			for(int channel = 0; channel < channel_count; ++channel)
+				dry_frame_buffer_[static_cast<size_t>(channel)] = samples[frame_offset + channel];
+
+			for(int channel = 0; channel < channel_count; ++channel)
+			{
+				float wet_sample = 0.0f;
+				const float input = detail::sanitize_denormal_sample(dry_frame_buffer_[static_cast<size_t>(channel)] * input_gain());
+				auto &comb_bank = comb_filters_[static_cast<size_t>(channel)];
+				for(auto &comb : comb_bank)
+					wet_sample += comb.process(input, comb_feedback, comb_damping);
+
+				auto &allpass_bank = allpass_filters_[static_cast<size_t>(channel)];
+				for(auto &allpass : allpass_bank)
+					wet_sample = allpass.process(wet_sample);
+
+				wet_frame_buffer_[static_cast<size_t>(channel)] = detail::sanitize_denormal_sample(wet_sample);
+			}
+
+			if(channel_count == 2)
+			{
+				const float wet_left = wet_frame_buffer_[0];
+				const float wet_right = wet_frame_buffer_[1];
+				samples[frame_offset] = detail::sanitize_denormal_sample(dry_frame_buffer_[0] * dry + wet_left * wet_1 + wet_right * wet_2);
+				samples[frame_offset + 1] = detail::sanitize_denormal_sample(dry_frame_buffer_[1] * dry + wet_right * wet_1 + wet_left * wet_2);
+			}
+			else
+			{
+				for(int channel = 0; channel < channel_count; ++channel)
+					samples[frame_offset + channel] = detail::sanitize_denormal_sample(
+						dry_frame_buffer_[static_cast<size_t>(channel)] * dry + wet_frame_buffer_[static_cast<size_t>(channel)] * wet);
+			}
+		}
+	}
+
+private:
+	static constexpr size_t comb_filter_count = 8;
+	static constexpr size_t allpass_filter_count = 4;
+
+	static constexpr float input_gain() { return 0.015f; }
+	static constexpr int stereo_spread_samples() { return 23; }
+
+	static constexpr std::array<int, comb_filter_count> comb_tunings()
+	{
+		return {1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617};
+	}
+
+	static constexpr std::array<int, allpass_filter_count> allpass_tunings()
+	{
+		return {556, 441, 341, 225};
+	}
+
+	static int scale_delay_frames(int tuning, int sample_rate, int channel)
+	{
+		const int stereo_spread = channel % 2 ? stereo_spread_samples() : 0;
+		const float scale = static_cast<float>(sample_rate > 0 ? sample_rate : 44100) / 44100.0f;
+		return std::max(static_cast<int>(std::lround(static_cast<float>(tuning + stereo_spread) * scale)), 1);
+	}
+
+	static float room_size_to_comb_feedback(float room_size)
+	{
+		return 0.7f + sanitize_room_size(room_size) * 0.28f;
+	}
+
+	static float damping_to_comb_damping(float damping)
+	{
+		return sanitize_damping(damping) * 0.4f;
+	}
+
+	static float sanitize_room_size(float room_size)
+	{
+		return std::clamp(room_size, 0.0f, 1.0f);
+	}
+
+	static float sanitize_damping(float damping)
+	{
+		return std::clamp(damping, 0.0f, 1.0f);
+	}
+
+	static float sanitize_mix(float mix)
+	{
+		return std::clamp(mix, 0.0f, 1.0f);
+	}
+
+	static float sanitize_width(float width)
+	{
+		return std::clamp(width, 0.0f, 1.0f);
+	}
+
+	std::atomic<int> sample_rate_ {44100};
+	std::atomic<int> channel_count_ {1};
+	std::atomic<float> room_size_;
+	std::atomic<float> damping_;
+	std::atomic<float> wet_;
+	std::atomic<float> dry_;
+	std::atomic<float> width_;
+
+	std::vector<std::array<detail::ReverbCombFilter, comb_filter_count>> comb_filters_;
+	std::vector<std::array<detail::ReverbAllPassFilter, allpass_filter_count>> allpass_filters_;
+	std::vector<float> wet_frame_buffer_;
+	std::vector<float> dry_frame_buffer_;
+};
+
+class VibratoEffect final : public detail::ModulatedDelayEffectBase {
+public:
+	VibratoEffect(float delay_ms = 6.0f, float depth_ms = 2.0f, float rate_hz = 4.5f, float stereo_phase_deg = 90.0f)
+		: ModulatedDelayEffectBase(delay_ms, depth_ms, rate_hz, stereo_phase_deg)
+	{
+	}
+
+private:
+	float output_sample(float, float wet) const override
+	{
+		return wet;
+	}
+
+	float delay_input_sample(float dry, float) const override
+	{
+		return dry;
+	}
+};
+
+class ChorusEffect final : public detail::MixedFeedbackModulatedDelayEffectBase {
+public:
+	ChorusEffect(float delay_ms = 18.0f, float depth_ms = 2.0f, float rate_hz = 0.25f, float mix = 0.35f,
+				 float feedback = 0.0f, float stereo_phase_deg = 90.0f)
+		: MixedFeedbackModulatedDelayEffectBase(delay_ms, depth_ms, rate_hz, mix, feedback, stereo_phase_deg,
+			0.0f,
+			max_feedback_limit())
+	{
+	}
+
+private:
+	static constexpr float max_feedback_limit() { return 0.95f; }
+};
+
+class FlangerEffect final : public detail::MixedFeedbackModulatedDelayEffectBase {
+public:
+	FlangerEffect(float delay_ms = 2.0f, float depth_ms = 1.5f, float rate_hz = 0.2f, float mix = 0.6f,
+				  float feedback = 0.72f, float stereo_phase_deg = 90.0f)
+		: MixedFeedbackModulatedDelayEffectBase(delay_ms, depth_ms, rate_hz, mix, feedback, stereo_phase_deg,
+			min_feedback_limit(),
+			max_feedback_limit())
+	{
+	}
+
+private:
+	static constexpr float min_feedback_limit() { return -0.98f; }
+	static constexpr float max_feedback_limit() { return 0.98f; }
+};
+
+} // namespace majimix
+
+#endif

--- a/majimix.hpp.in
+++ b/majimix.hpp.in
@@ -180,6 +180,10 @@ struct PlaybackEvent {
 
 using PlaybackEventCallback = void (*)(const PlaybackEvent& event, void *user_data);
 
+using EffectHandle = int;
+constexpr EffectHandle InvalidEffectHandle = 0;
+class AudioEffect;
+
 
 
 class Majimix {
@@ -418,6 +422,52 @@ public:
 	 * @param [in] user_data opaque user pointer passed back to the callback.
 	 */
 	virtual void set_playback_event_callback(PlaybackEventCallback callback, void *user_data = nullptr) = 0;
+
+
+	/* ---------------- EFFECTS -------------------*/
+
+	/**
+	 * @brief Add an effect to the master processing chain.
+	 *
+	 * Effects are executed in insertion order. The same effect instance should not be attached
+	 * to multiple chains at the same time.
+	 *
+	 * @param [in] effect effect instance to attach
+	 * @return EffectHandle unique effect handle or InvalidEffectHandle on failure
+	 */
+	virtual EffectHandle add_master_effect(const std::shared_ptr<AudioEffect>& effect) = 0;
+
+	/**
+	 * @brief Add an effect to a playback processing chain.
+	 *
+	 * The playback handle must be a valid handle returned by play_source.
+	 * Effects are executed in insertion order.
+	 *
+	 * @param [in] play_handle playback handle returned by play_source
+	 * @param [in] effect effect instance to attach
+	 * @return EffectHandle unique effect handle or InvalidEffectHandle on failure
+	 */
+	virtual EffectHandle add_playback_effect(int play_handle, const std::shared_ptr<AudioEffect>& effect) = 0;
+
+	/**
+	 * @brief Remove a previously added effect from its chain.
+	 *
+	 * @param [in] effect_handle effect handle returned by add_master_effect or add_playback_effect
+	 * @return True if an effect was removed, false otherwise
+	 */
+	virtual bool remove_effect(EffectHandle effect_handle) = 0;
+
+	/**
+	 * @brief Remove every effect from the master processing chain.
+	 */
+	virtual void clear_master_effects() = 0;
+
+	/**
+	 * @brief Remove every effect from a playback processing chain.
+	 *
+	 * @param [in] play_handle playback handle returned by play_source
+	 */
+	virtual void clear_playback_effects(int play_handle) = 0;
 
 
 	/**

--- a/src/majimix.cpp
+++ b/src/majimix.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <majimix/majimix.hpp>
+#include <majimix/effects.hpp>
 #include "wave.hpp"
 // #include <cstring>
 #include <portaudio.h>
@@ -135,10 +136,21 @@ class MajimixPa : public Majimix  {
 	std::atomic<unsigned int> playback_callback_version {0};
 	std::atomic<PlaybackEventCallback> playback_callback {nullptr};
 	std::atomic<void *> playback_callback_user_data {nullptr};
+	struct EffectChainEntry {
+		EffectHandle handle = InvalidEffectHandle;
+		std::shared_ptr<AudioEffect> effect;
+	};
+	using EffectChain = std::vector<EffectChainEntry>;
+	std::mutex effects_mutex;
+	EffectHandle next_effect_handle = InvalidEffectHandle + 1;
+	EffectChain master_effect_chain;
+	std::vector<EffectChain> playback_effect_chains;
 
 	/* internal mixing data */
 	std::vector<int32_t> internal_mix_buffer;
 	std::vector<int32_t> internal_sample_buffer;
+	std::vector<float> internal_float_mix_buffer;
+	std::vector<float> internal_float_sample_buffer;
 
 	/* audio converter */
 
@@ -152,6 +164,19 @@ class MajimixPa : public Majimix  {
 	void encode_Nbits(std::vector<char>::iterator it_out, int vol);
 	using fn_encode = std::function<void(std::vector<char>::iterator it_out, int vol)>;
 	fn_encode encode;
+	EffectHandle allocate_effect_handle_locked();
+	int get_playback_effect_chain_index(int play_handle) const;
+	bool is_effect_instance_attached_locked(const std::shared_ptr<AudioEffect>& effect) const;
+	void prepare_effect(AudioEffect &effect) const;
+	void prepare_master_effects();
+	void reset_effect_chain(EffectChain &chain);
+	void clear_playback_effect_chain_locked(int channel_index);
+	void clear_playback_effect_chain(int channel_index);
+	void clear_all_playback_effects_locked();
+	void apply_effect_chain(const EffectChain &chain, float *samples, int frame_count);
+	void convert_int_buffer_to_float(const int32_t *input, float *output, int sample_count) const;
+	void accumulate_int_buffer_to_float(const int32_t *input, float *output, int sample_count) const;
+	void convert_float_buffer_to_int(const float *input, int32_t *output, int sample_count) const;
 
 	bool get_playback_event_callback(PlaybackEventCallback &callback, void *&user_data) const;
 	void emit_playback_event(const PlaybackEvent &event) const;
@@ -253,6 +278,11 @@ public:
 	void stop_playback(int play_handle) override;
 	void set_loop(int play_handle, bool loop) override;
 	void set_playback_event_callback(PlaybackEventCallback callback, void *user_data = nullptr) override;
+	EffectHandle add_master_effect(const std::shared_ptr<AudioEffect>& effect) override;
+	EffectHandle add_playback_effect(int play_handle, const std::shared_ptr<AudioEffect>& effect) override;
+	bool remove_effect(EffectHandle effect_handle) override;
+	void clear_master_effects() override;
+	void clear_playback_effects(int play_handle) override;
     void pause_resume_playback(int play_handle, bool pause) override;
 
 	void pause_producer(bool);
@@ -298,6 +328,12 @@ bool MajimixPa::set_format(int rate, bool stereo, int bits, int channel_count)
 			sampling_rate = rate;
 			channels      = stereo ? 2 : 1;
 			this->bits    = bits;
+			{
+				std::lock_guard<std::mutex> lock(effects_mutex);
+				clear_all_playback_effects_locked();
+				playback_effect_chains.clear();
+				playback_effect_chains.resize(static_cast<size_t>(channel_count));
+			}
 			mixer_channels.clear();
 			mixer_channels.reserve(channel_count);
 			for(int i = 0; i < channel_count; ++i)
@@ -329,6 +365,8 @@ bool MajimixPa::set_format(int rate, bool stereo, int bits, int channel_count)
 				buffer_sample_size = mixer->get_buffer_packet_sample_size();
 			}
 
+			prepare_master_effects();
+
 			return set_mixer_buffer_parameters(buffer_count, buffer_sample_size);
 		}
 	}
@@ -343,6 +381,13 @@ bool MajimixPa::set_mixer_buffer_parameters(int buffer_count, int buffer_sample_
 	size_t buffer_size = static_cast<long>(mixer->get_buffer_packet_sample_size()) * channels;
 	internal_sample_buffer.assign(buffer_size, 0);
 	internal_mix_buffer.assign(buffer_size, 0);
+	internal_float_sample_buffer.assign(buffer_size, 0.0f);
+	internal_float_mix_buffer.assign(buffer_size, 0.0f);
+	{
+		std::lock_guard<std::mutex> lock(effects_mutex);
+		if(playback_effect_chains.size() != mixer_channels.size())
+			playback_effect_chains.resize(mixer_channels.size());
+	}
 
 	mixer->set_mixer_function(std::bind(&MajimixPa::mix, this, std::placeholders::_1, std::placeholders::_2));
 
@@ -352,6 +397,146 @@ bool MajimixPa::set_mixer_buffer_parameters(int buffer_count, int buffer_sample_
 			cartridge->reserve_lines_buffer(mixer->get_buffer_packet_sample_size());
 
 	return true;
+}
+
+EffectHandle MajimixPa::allocate_effect_handle_locked()
+{
+	if(next_effect_handle <= InvalidEffectHandle)
+		next_effect_handle = InvalidEffectHandle + 1;
+	return next_effect_handle++;
+}
+
+int MajimixPa::get_playback_effect_chain_index(int play_handle) const
+{
+	if(get_source_type(play_handle) != 0)
+		return -1;
+
+	const unsigned int source_id = get_source_id(play_handle);
+	const unsigned int channel_id = get_channel_id(play_handle);
+	if(source_id == 0 || channel_id == 0 || channel_id > mixer_channels.size())
+		return -1;
+
+	const auto &channel = mixer_channels[channel_id - 1];
+	if(!channel->active.load(std::memory_order_acquire) || channel->stopped.load(std::memory_order_acquire))
+		return -1;
+	if(channel->sid.load(std::memory_order_acquire) != static_cast<int>(source_id))
+		return -1;
+	if(channel_id - 1 >= playback_effect_chains.size())
+		return -1;
+
+	return static_cast<int>(channel_id) - 1;
+}
+
+bool MajimixPa::is_effect_instance_attached_locked(const std::shared_ptr<AudioEffect>& effect) const
+{
+	if(!effect)
+		return false;
+
+	for(const auto &entry : master_effect_chain)
+		if(entry.effect == effect)
+			return true;
+
+	for(const auto &chain : playback_effect_chains)
+		for(const auto &entry : chain)
+			if(entry.effect == effect)
+				return true;
+
+	return false;
+}
+
+void MajimixPa::prepare_effect(AudioEffect &effect) const
+{
+	effect.prepare(sampling_rate, channels);
+	effect.reset();
+}
+
+void MajimixPa::prepare_master_effects()
+{
+	std::lock_guard<std::mutex> lock(effects_mutex);
+	for(auto &entry : master_effect_chain)
+		if(entry.effect)
+			prepare_effect(*entry.effect);
+}
+
+void MajimixPa::reset_effect_chain(EffectChain &chain)
+{
+	for(auto &entry : chain)
+		if(entry.effect)
+			entry.effect->reset();
+}
+
+void MajimixPa::clear_playback_effect_chain_locked(int channel_index)
+{
+	if(channel_index < 0 || channel_index >= static_cast<int>(playback_effect_chains.size()))
+		return;
+
+	reset_effect_chain(playback_effect_chains[channel_index]);
+	playback_effect_chains[channel_index].clear();
+}
+
+void MajimixPa::clear_playback_effect_chain(int channel_index)
+{
+	std::lock_guard<std::mutex> lock(effects_mutex);
+	clear_playback_effect_chain_locked(channel_index);
+}
+
+void MajimixPa::clear_all_playback_effects_locked()
+{
+	for(auto &chain : playback_effect_chains)
+	{
+		reset_effect_chain(chain);
+		chain.clear();
+	}
+}
+
+void MajimixPa::apply_effect_chain(const EffectChain &chain, float *samples, int frame_count)
+{
+	if(!samples || frame_count <= 0)
+		return;
+
+	for(const auto &entry : chain)
+		if(entry.effect)
+			entry.effect->process(samples, frame_count);
+}
+
+void MajimixPa::convert_int_buffer_to_float(const int32_t *input, float *output, int sample_count) const
+{
+	if(!input || !output || sample_count <= 0)
+		return;
+
+	const float scale = bits == 24 ? (1.0f / 8388608.0f) : (1.0f / 32768.0f);
+	for(int i = 0; i < sample_count; ++i)
+		output[i] = static_cast<float>(input[i]) * scale;
+}
+
+void MajimixPa::accumulate_int_buffer_to_float(const int32_t *input, float *output, int sample_count) const
+{
+	if(!input || !output || sample_count <= 0)
+		return;
+
+	const float scale = bits == 24 ? (1.0f / 8388608.0f) : (1.0f / 32768.0f);
+	for(int i = 0; i < sample_count; ++i)
+		output[i] += static_cast<float>(input[i]) * scale;
+}
+
+void MajimixPa::convert_float_buffer_to_int(const float *input, int32_t *output, int sample_count) const
+{
+	if(!input || !output || sample_count <= 0)
+		return;
+
+	const float scale = bits == 24 ? 8388608.0f : 32768.0f;
+	const int32_t min_value = bits == 24 ? -(1 << 23) : -(1 << 15);
+	const int32_t max_value = bits == 24 ? ((1 << 23) - 1) : ((1 << 15) - 1);
+	for(int i = 0; i < sample_count; ++i)
+	{
+		const float scaled = input[i] * scale;
+		if(scaled <= static_cast<float>(min_value))
+			output[i] = min_value;
+		else if(scaled >= static_cast<float>(max_value))
+			output[i] = max_value;
+		else
+			output[i] = static_cast<int32_t>(scaled);
+	}
 }
 
 bool MajimixPa::get_playback_event_callback(PlaybackEventCallback &callback, void *&user_data) const
@@ -414,6 +599,7 @@ void MajimixPa::drop_regular_channel(MixerChannel &channel, int channel_id, Play
 	const int source_id = channel.sid.load(std::memory_order_acquire);
 	if(was_active)
 		emit_stop_event(source_id, channel_id, reason);
+	clear_playback_effect_chain(channel_id - 1);
 
 	channel.stopped = true;
 	channel.paused = false;
@@ -713,6 +899,7 @@ int MajimixPa::play_source(int source_handle, bool loop, bool paused)
 			++pid;
 			if(!mix_channel->active)
 			{
+				clear_playback_effect_chain(pid - 1);
 				if(mix_channel->sid != source_id)
 				{
 					mix_channel->sid     = source_id;
@@ -737,7 +924,7 @@ int MajimixPa::play_source(int source_handle, bool loop, bool paused)
 
 int MajimixPa::play_kss_track(int kss_source_handle, int track, bool autostop, bool forcable, bool force)
 {
-	return kss_cartridge_action<int>(kss_source_handle, false, false, 0, [&](kss::CartridgeKSS &cartridge, int line_id) -> int {
+	return kss_cartridge_action<int>(kss_source_handle, false, false, 0, [&](kss::CartridgeKSS &cartridge, int) -> int {
 		int id = cartridge.active_line(track, autostop, forcable);
 		if(!id && force)
 		{
@@ -792,6 +979,7 @@ void MajimixPa::stop_playback(int play_handle)
 					emit_stop_event(source_id, channel_id, PlaybackStopReason::ExplicitStop);
 					mix_channel->loop = false;   // XXX needed ?
 					mix_channel->active = false; // XXX needed ?
+					clear_playback_effect_chain(channel_id - 1);
 					mix_channel->stop_reason = PlaybackStopReason::EndOfStream;
 				}
 			}
@@ -835,7 +1023,8 @@ void MajimixPa::stop_playback(int play_handle)
 					if(!m_stream) 
 					{
 						emit_stop_event(static_cast<int>(source_id), static_cast<int>(channel_id), PlaybackStopReason::ExplicitStop);
-							channel->active = false;
+						channel->active = false;
+						clear_playback_effect_chain(static_cast<int>(channel_id) - 1);
 						channel->stop_reason = PlaybackStopReason::EndOfStream;
 					}
 				}
@@ -854,6 +1043,7 @@ void MajimixPa::stop_playback(int play_handle)
 						{
 							emit_stop_event(static_cast<int>(source_id), current_channel_id, PlaybackStopReason::ExplicitStop);
 							channel->active = false;
+							clear_playback_effect_chain(current_channel_id - 1);
 							channel->stop_reason = PlaybackStopReason::EndOfStream;
 						}
 					}
@@ -912,6 +1102,81 @@ void MajimixPa::set_playback_event_callback(PlaybackEventCallback callback, void
 	playback_callback.store(callback, std::memory_order_release);
 	playback_callback_user_data.store(user_data, std::memory_order_release);
 	playback_callback_version.fetch_add(1, std::memory_order_acq_rel);
+}
+
+EffectHandle MajimixPa::add_master_effect(const std::shared_ptr<AudioEffect>& effect)
+{
+	if(!effect)
+		return InvalidEffectHandle;
+
+	std::lock_guard<std::mutex> lock(effects_mutex);
+	if(is_effect_instance_attached_locked(effect))
+		return InvalidEffectHandle;
+
+	prepare_effect(*effect);
+	const EffectHandle effect_handle = allocate_effect_handle_locked();
+	master_effect_chain.push_back({effect_handle, effect});
+	return effect_handle;
+}
+
+EffectHandle MajimixPa::add_playback_effect(int play_handle, const std::shared_ptr<AudioEffect>& effect)
+{
+	if(!effect)
+		return InvalidEffectHandle;
+
+	std::lock_guard<std::mutex> lock(effects_mutex);
+	const int chain_index = get_playback_effect_chain_index(play_handle);
+	if(chain_index < 0 || is_effect_instance_attached_locked(effect))
+		return InvalidEffectHandle;
+
+	prepare_effect(*effect);
+	const EffectHandle effect_handle = allocate_effect_handle_locked();
+	playback_effect_chains[chain_index].push_back({effect_handle, effect});
+	return effect_handle;
+}
+
+bool MajimixPa::remove_effect(EffectHandle effect_handle)
+{
+	if(effect_handle == InvalidEffectHandle)
+		return false;
+
+	auto remove_from_chain = [&](EffectChain &chain) -> bool {
+		auto it = std::find_if(chain.begin(), chain.end(), [effect_handle](const EffectChainEntry &entry) {
+			return entry.handle == effect_handle;
+		});
+		if(it == chain.end())
+			return false;
+
+		if(it->effect)
+			it->effect->reset();
+		chain.erase(it);
+		return true;
+	};
+
+	std::lock_guard<std::mutex> lock(effects_mutex);
+	if(remove_from_chain(master_effect_chain))
+		return true;
+
+	for(auto &chain : playback_effect_chains)
+		if(remove_from_chain(chain))
+			return true;
+
+	return false;
+}
+
+void MajimixPa::clear_master_effects()
+{
+	std::lock_guard<std::mutex> lock(effects_mutex);
+	reset_effect_chain(master_effect_chain);
+	master_effect_chain.clear();
+}
+
+void MajimixPa::clear_playback_effects(int play_handle)
+{
+	std::lock_guard<std::mutex> lock(effects_mutex);
+	const int chain_index = get_playback_effect_chain_index(play_handle);
+	if(chain_index >= 0)
+		clear_playback_effect_chain_locked(chain_index);
 }
 
 
@@ -1028,10 +1293,11 @@ void MajimixPa::mix(std::vector<char>::iterator it_out, int requested_sample_cou
 	//auto it_begin = it_out;
 	int sample_count;
 	bool deactivate;
-	bool mix_buffer_has_data = false;
 	int channel_id = 0;
+	const int requested_data_count = requested_sample_count * channels;
 
 	std::fill(internal_mix_buffer.begin(), internal_mix_buffer.end(), 0);
+	std::fill(internal_float_mix_buffer.begin(), internal_float_mix_buffer.end(), 0.0f);
 
 	for(auto& mix_channel : mixer_channels)
 	{
@@ -1041,22 +1307,21 @@ void MajimixPa::mix(std::vector<char>::iterator it_out, int requested_sample_cou
 			const int source_id = mix_channel->sid.load(std::memory_order_acquire);
 			int loop_count = 0;
 			sample_count = 0;
-			deactivate =  false;
+			deactivate = false;
 			if(mix_channel->stopped || !mix_channel->sample)
 			{
 				deactivate = true;
 			}
 			else if(!mix_channel->paused)
 			{
-				int *target_buffer = mix_buffer_has_data ? internal_sample_buffer.data() : internal_mix_buffer.data();
-				sample_count = mix_channel->sample->read(target_buffer, requested_sample_count);
+				sample_count = mix_channel->sample->read(internal_sample_buffer.data(), requested_sample_count);
 				if(mix_channel->loop && sample_count < requested_sample_count)
 				{
 					while(sample_count < requested_sample_count)
 					{
-						// EOF - AUTOLOOP 
+						// EOF - AUTOLOOP
 						long idx = static_cast<long>(sample_count) * channels;
-						int loop_sample_count = mix_channel->sample->read(target_buffer + idx, requested_sample_count - sample_count);
+						int loop_sample_count = mix_channel->sample->read(internal_sample_buffer.data() + idx, requested_sample_count - sample_count);
 						if(loop_sample_count <= 0)
 							break;
 						sample_count += loop_sample_count;
@@ -1069,24 +1334,25 @@ void MajimixPa::mix(std::vector<char>::iterator it_out, int requested_sample_cou
 
 				if(sample_count)
 				{
-					if(mix_buffer_has_data)
+					const int mixed_sample_count = sample_count * channels;
+					convert_int_buffer_to_float(internal_sample_buffer.data(), internal_float_sample_buffer.data(), mixed_sample_count);
 					{
-						std::transform(internal_sample_buffer.begin(), internal_sample_buffer.begin() + static_cast<long>(sample_count) * channels, internal_mix_buffer.begin(), internal_mix_buffer.begin(), std::plus<int>());
+						std::lock_guard<std::mutex> lock(effects_mutex);
+						if(channel_id - 1 < static_cast<int>(playback_effect_chains.size()))
+							apply_effect_chain(playback_effect_chains[channel_id - 1], internal_float_sample_buffer.data(), sample_count);
 					}
-					else
-					{
-						mix_buffer_has_data = true;
-					}
+					std::transform(internal_float_sample_buffer.begin(), internal_float_sample_buffer.begin() + mixed_sample_count, internal_float_mix_buffer.begin(), internal_float_mix_buffer.begin(), std::plus<float>());
 				}
+
 				if(sample_count < requested_sample_count)
-				{
 					deactivate = true;
-				}
 			}
+
 			if(deactivate)
 			{
 				const PlaybackStopReason stop_reason = mix_channel->stop_reason.load(std::memory_order_acquire);
 				emit_stop_event(source_id, channel_id, stop_reason);
+				clear_playback_effect_chain(channel_id - 1);
 				mix_channel->stopped = true;
 				mix_channel->active = false;
 				mix_channel->stop_reason = PlaybackStopReason::EndOfStream;
@@ -1095,14 +1361,22 @@ void MajimixPa::mix(std::vector<char>::iterator it_out, int requested_sample_cou
 	}
 
 	// kss support
-
 	for(auto &ck : kss_cartridges)
 	{
 		if(ck)
 		{
-			ck->read(internal_mix_buffer.begin(), requested_sample_count);
+			std::fill(internal_sample_buffer.begin(), internal_sample_buffer.begin() + requested_data_count, 0);
+			ck->read(internal_sample_buffer.begin(), requested_sample_count);
+			accumulate_int_buffer_to_float(internal_sample_buffer.data(), internal_float_mix_buffer.data(), requested_data_count);
 		}
 	}
+
+	{
+		std::lock_guard<std::mutex> lock(effects_mutex);
+		apply_effect_chain(master_effect_chain, internal_float_mix_buffer.data(), requested_sample_count);
+	}
+
+	convert_float_buffer_to_int(internal_float_mix_buffer.data(), internal_mix_buffer.data(), requested_data_count);
 
 	// Apply master volume and encode in one pass to reduce memory traffic.
 	encode(it_out, master_volume.load());
@@ -1131,10 +1405,10 @@ void MajimixPa::encode_Nbits(std::vector<char>::iterator it_out, int vol)
 ** It may called at interrupt level on some machines so don't do anything
 ** that could mess up the system like calling malloc() or free().
  */
-int MajimixPa::paCallback(const void *input_buffer, void *output_buffer,
+int MajimixPa::paCallback(const void *, void *output_buffer,
 						   unsigned long frames_per_buffer,
-						   const PaStreamCallbackTimeInfo* timeInfo,
-						   PaStreamCallbackFlags statusFlags,
+					   const PaStreamCallbackTimeInfo*,
+					   PaStreamCallbackFlags,
 						   void *userData ) {
 //	static_cast<MajimixPa*>(userData)->read((char *) output_buffer, frames_per_buffer);
 	reinterpret_cast<MajimixPa*>(userData)->read((char *) output_buffer, frames_per_buffer);
@@ -1215,7 +1489,7 @@ bool MajimixPa::update_kss_frequency(int kss_handle, int frequency)
 
 int MajimixPa::get_kss_active_lines_count(int kss_source_handle)
 {
-	 return kss_cartridge_action<int>(kss_source_handle, false, false, 0, [](kss::CartridgeKSS& cartridge, int line_id) -> int 
+	 return kss_cartridge_action<int>(kss_source_handle, false, false, 0, [](kss::CartridgeKSS& cartridge, int) -> int 
 	 {
 		int nb = 0;
 		for(auto &l : cartridge)

--- a/tests/effects_smoke.cpp
+++ b/tests/effects_smoke.cpp
@@ -1,0 +1,354 @@
+#include <cmath>
+#include <iostream>
+
+#include <majimix/effects.hpp>
+
+namespace {
+
+bool nearly_equal(float lhs, float rhs, float epsilon = 1e-4f)
+{
+	return std::fabs(lhs - rhs) <= epsilon;
+}
+
+bool expect(bool condition, const char *message)
+{
+	if(condition)
+		return true;
+
+	std::cerr << "effects_smoke failure: " << message << "\n";
+	return false;
+}
+
+bool test_gain_effect()
+{
+	majimix::GainEffect effect(0.5f);
+	effect.prepare(44100, 2);
+
+	float samples[] = {1.0f, -1.0f, 0.5f, -0.5f};
+	effect.process(samples, 2);
+
+	return expect(nearly_equal(samples[0], 0.5f), "gain left sample mismatch") &&
+		expect(nearly_equal(samples[1], -0.5f), "gain right sample mismatch") &&
+		expect(nearly_equal(samples[2], 0.25f), "gain third sample mismatch") &&
+		expect(nearly_equal(samples[3], -0.25f), "gain fourth sample mismatch");
+}
+
+bool test_fade_in_helper()
+{
+	majimix::FadeEffect effect(0.0f);
+	effect.prepare(1000, 2);
+	effect.fade_in(4);
+
+	float samples[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+	effect.process(samples, 4);
+
+	return expect(nearly_equal(samples[0], 0.0f), "fade_in frame 0 mismatch") &&
+		expect(nearly_equal(samples[2], 0.25f), "fade_in frame 1 mismatch") &&
+		expect(nearly_equal(samples[4], 0.5f), "fade_in frame 2 mismatch") &&
+		expect(nearly_equal(samples[6], 0.75f), "fade_in frame 3 mismatch") &&
+		expect(nearly_equal(effect.get_current_gain(), 1.0f), "fade_in final gain mismatch") &&
+		expect(nearly_equal(effect.get_target_gain(), 1.0f), "fade_in target gain mismatch");
+}
+
+bool test_fade_out_helper()
+{
+	majimix::FadeEffect effect(1.0f);
+	effect.prepare(1000, 2);
+	effect.fade_out(4);
+
+	float samples[] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+	effect.process(samples, 4);
+
+	return expect(nearly_equal(samples[0], 1.0f), "fade_out frame 0 mismatch") &&
+		expect(nearly_equal(samples[2], 0.75f), "fade_out frame 1 mismatch") &&
+		expect(nearly_equal(samples[4], 0.5f), "fade_out frame 2 mismatch") &&
+		expect(nearly_equal(samples[6], 0.25f), "fade_out frame 3 mismatch") &&
+		expect(nearly_equal(effect.get_current_gain(), 0.0f), "fade_out final gain mismatch") &&
+		expect(nearly_equal(effect.get_target_gain(), 0.0f), "fade_out target gain mismatch");
+}
+
+bool test_immediate_gain_update()
+{
+	majimix::FadeEffect effect(0.0f);
+	effect.prepare(48000, 2);
+	effect.set_gain(0.25f);
+
+	float samples[] = {1.0f, 1.0f};
+	effect.process(samples, 1);
+
+	return expect(nearly_equal(samples[0], 0.25f), "immediate gain left mismatch") &&
+		expect(nearly_equal(samples[1], 0.25f), "immediate gain right mismatch") &&
+		expect(nearly_equal(effect.get_current_gain(), 0.25f), "immediate gain state mismatch");
+}
+
+bool test_reverb_dry_passthrough()
+{
+	majimix::ReverbEffect effect(0.65f, 0.25f, 0.0f, 1.0f, 1.0f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, -0.5f, 0.25f};
+	effect.process(samples, 3);
+
+	return expect(nearly_equal(samples[0], 1.0f), "reverb passthrough sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], -0.5f), "reverb passthrough sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], 0.25f), "reverb passthrough sample 2 mismatch");
+}
+
+bool test_reverb_impulse_tail()
+{
+	majimix::ReverbEffect effect(0.7f, 0.2f, 1.0f, 0.0f, 1.0f);
+	effect.prepare(1000, 1);
+
+	float samples[64] = {};
+	samples[0] = 1.0f;
+	effect.process(samples, 64);
+
+	float max_tail = 0.0f;
+	for(int i = 1; i < 64; ++i)
+	{
+		const float magnitude = std::fabs(samples[i]);
+		if(magnitude > max_tail)
+			max_tail = magnitude;
+	}
+
+	return expect(nearly_equal(samples[0], 0.0f), "reverb first sample mismatch") &&
+		expect(max_tail > 1e-4f, "reverb tail missing");
+}
+
+bool test_reverb_reset_clears_tail()
+{
+	majimix::ReverbEffect effect(0.7f, 0.2f, 1.0f, 0.0f, 1.0f);
+	effect.prepare(1000, 1);
+
+	float impulse[64] = {};
+	impulse[0] = 1.0f;
+	effect.process(impulse, 64);
+
+	effect.reset();
+
+	float silence[64] = {};
+	effect.process(silence, 64);
+
+	float max_output = 0.0f;
+	for(float sample : silence)
+	{
+		const float magnitude = std::fabs(sample);
+		if(magnitude > max_output)
+			max_output = magnitude;
+	}
+
+	return expect(max_output <= 1e-6f, "reverb reset tail mismatch");
+}
+
+bool test_reverb_parameter_clamp()
+{
+	majimix::ReverbEffect effect;
+	effect.set_room_size(-5.0f);
+	effect.set_damping(2.0f);
+	effect.set_wet(-1.0f);
+	effect.set_dry(2.0f);
+	effect.set_width(-2.0f);
+	const bool lower_width_clamp_ok = nearly_equal(effect.get_width(), 0.0f);
+	effect.set_width(2.0f);
+
+	return expect(nearly_equal(effect.get_room_size(), 0.0f), "reverb room size clamp mismatch") &&
+		expect(nearly_equal(effect.get_damping(), 1.0f), "reverb damping clamp mismatch") &&
+		expect(nearly_equal(effect.get_wet(), 0.0f), "reverb wet clamp mismatch") &&
+		expect(nearly_equal(effect.get_dry(), 1.0f), "reverb dry clamp mismatch") &&
+		expect(lower_width_clamp_ok, "reverb lower width clamp mismatch") &&
+		expect(nearly_equal(effect.get_width(), 1.0f), "reverb width clamp mismatch");
+}
+
+bool test_vibrato_zero_delay_passthrough()
+{
+	majimix::VibratoEffect effect(0.0f, 0.0f, 0.0f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, -0.5f, 0.25f};
+	effect.process(samples, 3);
+
+	return expect(nearly_equal(samples[0], 1.0f), "vibrato passthrough sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], -0.5f), "vibrato passthrough sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], 0.25f), "vibrato passthrough sample 2 mismatch");
+}
+
+bool test_vibrato_fixed_delay()
+{
+	majimix::VibratoEffect effect(1.0f, 0.0f, 0.0f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, 0.0f, 0.0f, 0.0f};
+	effect.process(samples, 4);
+
+	return expect(nearly_equal(samples[0], 0.0f), "vibrato delay sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], 1.0f), "vibrato delay sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], 0.0f), "vibrato delay sample 2 mismatch") &&
+		expect(nearly_equal(samples[3], 0.0f), "vibrato delay sample 3 mismatch");
+}
+
+bool test_vibrato_parameter_clamp()
+{
+	majimix::VibratoEffect effect;
+	effect.set_delay_ms(-5.0f);
+	effect.set_depth_ms(999.0f);
+	effect.set_rate_hz(-2.0f);
+	effect.set_stereo_phase_deg(999.0f);
+
+	return expect(nearly_equal(effect.get_delay_ms(), 0.0f), "vibrato delay clamp mismatch") &&
+		expect(nearly_equal(effect.get_depth_ms(), 20.0f), "vibrato depth clamp mismatch") &&
+		expect(nearly_equal(effect.get_rate_hz(), 0.0f), "vibrato rate clamp mismatch") &&
+		expect(nearly_equal(effect.get_stereo_phase_deg(), 180.0f), "vibrato stereo phase clamp mismatch");
+}
+
+bool test_chorus_passthrough_mix_zero()
+{
+	majimix::ChorusEffect effect(1.0f, 0.0f, 0.0f, 0.0f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, -0.5f, 0.25f};
+	effect.process(samples, 3);
+
+	return expect(nearly_equal(samples[0], 1.0f), "chorus passthrough sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], -0.5f), "chorus passthrough sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], 0.25f), "chorus passthrough sample 2 mismatch");
+}
+
+bool test_chorus_fixed_delay()
+{
+	majimix::ChorusEffect effect(1.0f, 0.0f, 0.0f, 1.0f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, 0.0f, 0.0f, 0.0f};
+	effect.process(samples, 4);
+
+	return expect(nearly_equal(samples[0], 0.0f), "chorus delay sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], 1.0f), "chorus delay sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], 0.0f), "chorus delay sample 2 mismatch") &&
+		expect(nearly_equal(samples[3], 0.0f), "chorus delay sample 3 mismatch");
+}
+
+bool test_chorus_feedback_tail()
+{
+	majimix::ChorusEffect effect(1.0f, 0.0f, 0.0f, 1.0f, 0.5f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, 0.0f, 0.0f, 0.0f};
+	effect.process(samples, 4);
+
+	return expect(nearly_equal(samples[0], 0.0f), "chorus feedback sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], 1.0f), "chorus feedback sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], 0.5f), "chorus feedback sample 2 mismatch") &&
+		expect(nearly_equal(samples[3], 0.25f), "chorus feedback sample 3 mismatch");
+}
+
+bool test_chorus_parameter_clamp()
+{
+	majimix::ChorusEffect effect;
+	effect.set_delay_ms(-5.0f);
+	effect.set_depth_ms(999.0f);
+	effect.set_rate_hz(-2.0f);
+	effect.set_mix(2.0f);
+	effect.set_feedback(2.0f);
+	effect.set_stereo_phase_deg(999.0f);
+
+	return expect(nearly_equal(effect.get_delay_ms(), 0.0f), "chorus delay clamp mismatch") &&
+		expect(nearly_equal(effect.get_depth_ms(), 20.0f), "chorus depth clamp mismatch") &&
+		expect(nearly_equal(effect.get_rate_hz(), 0.0f), "chorus rate clamp mismatch") &&
+		expect(nearly_equal(effect.get_mix(), 1.0f), "chorus mix clamp mismatch") &&
+		expect(nearly_equal(effect.get_feedback(), 0.95f), "chorus feedback clamp mismatch") &&
+		expect(nearly_equal(effect.get_stereo_phase_deg(), 180.0f), "chorus stereo phase clamp mismatch");
+}
+
+bool test_flanger_fixed_delay_feedback_tail()
+{
+	majimix::FlangerEffect effect(1.0f, 0.0f, 0.0f, 1.0f, 0.75f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, 0.0f, 0.0f, 0.0f};
+	effect.process(samples, 4);
+
+	return expect(nearly_equal(samples[0], 0.0f), "flanger feedback sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], 1.0f), "flanger feedback sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], 0.75f), "flanger feedback sample 2 mismatch") &&
+		expect(nearly_equal(samples[3], 0.5625f), "flanger feedback sample 3 mismatch");
+}
+
+bool test_flanger_negative_feedback_tail()
+{
+	majimix::FlangerEffect effect(1.0f, 0.0f, 0.0f, 1.0f, -0.75f);
+	effect.prepare(1000, 1);
+
+	float samples[] = {1.0f, 0.0f, 0.0f, 0.0f};
+	effect.process(samples, 4);
+
+	return expect(nearly_equal(samples[0], 0.0f), "flanger negative feedback sample 0 mismatch") &&
+		expect(nearly_equal(samples[1], 1.0f), "flanger negative feedback sample 1 mismatch") &&
+		expect(nearly_equal(samples[2], -0.75f), "flanger negative feedback sample 2 mismatch") &&
+		expect(nearly_equal(samples[3], 0.5625f), "flanger negative feedback sample 3 mismatch");
+}
+
+bool test_flanger_parameter_clamp()
+{
+	majimix::FlangerEffect effect;
+	effect.set_delay_ms(-5.0f);
+	effect.set_depth_ms(999.0f);
+	effect.set_rate_hz(-2.0f);
+	effect.set_mix(2.0f);
+	effect.set_feedback(-2.0f);
+	const bool lower_clamp_ok = nearly_equal(effect.get_feedback(), -0.98f);
+	effect.set_feedback(2.0f);
+	effect.set_stereo_phase_deg(999.0f);
+
+	return expect(nearly_equal(effect.get_delay_ms(), 0.0f), "flanger delay clamp mismatch") &&
+		expect(nearly_equal(effect.get_depth_ms(), 20.0f), "flanger depth clamp mismatch") &&
+		expect(nearly_equal(effect.get_rate_hz(), 0.0f), "flanger rate clamp mismatch") &&
+		expect(nearly_equal(effect.get_mix(), 1.0f), "flanger mix clamp mismatch") &&
+		expect(lower_clamp_ok, "flanger negative feedback clamp mismatch") &&
+		expect(nearly_equal(effect.get_feedback(), 0.98f), "flanger feedback clamp mismatch") &&
+		expect(nearly_equal(effect.get_stereo_phase_deg(), 180.0f), "flanger stereo phase clamp mismatch");
+}
+
+} // namespace
+
+int main()
+{
+	if(!test_gain_effect())
+		return 1;
+	if(!test_fade_in_helper())
+		return 1;
+	if(!test_fade_out_helper())
+		return 1;
+	if(!test_immediate_gain_update())
+		return 1;
+	if(!test_reverb_dry_passthrough())
+		return 1;
+	if(!test_reverb_impulse_tail())
+		return 1;
+	if(!test_reverb_reset_clears_tail())
+		return 1;
+	if(!test_reverb_parameter_clamp())
+		return 1;
+	if(!test_vibrato_zero_delay_passthrough())
+		return 1;
+	if(!test_vibrato_fixed_delay())
+		return 1;
+	if(!test_vibrato_parameter_clamp())
+		return 1;
+	if(!test_chorus_passthrough_mix_zero())
+		return 1;
+	if(!test_chorus_fixed_delay())
+		return 1;
+	if(!test_chorus_feedback_tail())
+		return 1;
+	if(!test_chorus_parameter_clamp())
+		return 1;
+	if(!test_flanger_fixed_delay_feedback_tail())
+		return 1;
+	if(!test_flanger_negative_feedback_tail())
+		return 1;
+	if(!test_flanger_parameter_clamp())
+		return 1;
+
+	std::cout << "effects_smoke ok\n";
+	return 0;
+}


### PR DESCRIPTION
## Summary

- add the new master/playback audio effects pipeline and public effect API
- add the public effects header with GainEffect, FadeEffect, ReverbEffect, VibratoEffect, ChorusEffect and FlangerEffect
- add deterministic DSP smoke coverage for the built-in effects
- add example programs for fade, reverb, flanger, vibrato and chorus
- update the examples so the audio file is passed as the first command-line argument instead of shipping sample audio in the repository
- update the documentation and wire the examples/tests in CMake

## Testing

- Build_CMakeTools
- RunCtest_CMakeTools: majimix_effects_smoke